### PR TITLE
mode-disk: sync before `poweroff -f`

### DIFF
--- a/overlay/libexec/k3os/mode-disk
+++ b/overlay/libexec/k3os/mode-disk
@@ -135,6 +135,7 @@ takeover()
     
     if [ -e k3os/system/poweroff ]; then
         rm -f k3os/system/poweroff
+        sync
         poweroff -f
     else
         reboot -f


### PR DESCRIPTION
We should sync between making a filesystem change and a `poweroff -f`.